### PR TITLE
also run travis on 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.3
   - release
   - nightly
 notifications:


### PR DESCRIPTION
still supported according to REQUIRE, so should also be tested as long as that's the case