### PR TITLE
Preparing for upcoming change in PDMats

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.3
 Compat 0.4.0
-PDMats 0.3.2
+PDMats 0.3.2 0.4
 Distributions 0.8.1


### PR DESCRIPTION
PR JuliaStats/PDMats.jl#37 would need a small change to some typealiases in Distributions/MvNormal.jl. Some tests of the ConjugatePriors package rely on these typealiases, and need updating.

Therefore fixing upper boundary of PDMats to upcoming version of PDMats (0.4)

The corresponding PR for the same changes in METADATA is JuliaLang/METADATA.jl#4506