### PR TITLE
Bump dependency versions, drop 0.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: julia
 os:
-  - linux
   - osx
+  - linux
 julia:
-  - 0.3
   - 0.4
   - 0.5
   - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
+#script: # the default script is equivalent to the following
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("ConjugatePriors"); Pkg.test("ConjugatePriors"; coverage=true)'
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("ConjugatePriors"); Pkg.test("ConjugatePriors"; coverage=true)';
+after_success:
+  - julia -e 'cd(Pkg.dir("ConjugatePriors")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'cd(Pkg.dir("ConjugatePriors")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Compat 0.4.0
-PDMats 0.3.2 0.4
-Distributions 0.8.1
+PDMats 0.4.2
+Distributions 0.10.2


### PR DESCRIPTION
If this is all good then we can tag a new version so that this package works in the ecosystem again. Ref https://github.com/JuliaStats/ConjugatePriors.jl/pull/10#issuecomment-245166892
