### PR TITLE
Prevent numerical instability when sampling from Normal-Wishart

### DIFF
--- a/src/ConjugatePriors.jl
+++ b/src/ConjugatePriors.jl
@@ -8,6 +8,8 @@ using Distributions
 import Base: mean
 import Base.LinAlg: Cholesky
 
+import PDMats: PDMat
+
 import Distributions:
     BernoulliStats,
     BinomData,

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -3,7 +3,7 @@
 # a reference.  Note that there were some typos in that document so the code
 # here may not correspond exactly.
 
-struct NormalWishart{T<:Real} <: ContinuousUnivariateDistribution
+struct NormalWishart{T<:Real} <: ContinuousMultivariateDistribution
     dim::Int
     zeromean::Bool
     mu::Vector{T}

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -82,7 +82,6 @@ end
 
 function rand(nw::NormalWishart)
     Lam = rand(Wishart(nw.nu, nw.Tchol))
-    mu = rand(MvNormal(nw.mu, inv(Lam) ./ nw.kappa))
+    mu = rand(MvNormal(nw.mu, Hermitian(inv(Lam) ./ nw.kappa)) )
     return (mu, Lam)
 end
-

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -82,6 +82,7 @@ end
 
 function rand(nw::NormalWishart)
     Lam = rand(Wishart(nw.nu, nw.Tchol))
-    mu = rand(MvNormal(nw.mu, Hermitian(inv(Lam) ./ nw.kappa)) )
+    Lsym = PDMat(Symmetric(inv(Lam) ./ nw.kappa))
+    mu = rand(MvNormal(nw.mu, Lsym))
     return (mu, Lam)
 end


### PR DESCRIPTION
While using the rand function in normalwishart.jl I noticed that I frequently got errors thrown by Base.LinAlg.cholfact. I tracked this back and it appears that the matrix inv(Lam) ./ nw.kappa sometimes has differences in its off-diagonal elements of ~1e-18, which then get detected as errors when passing this matrix to MvNormal (since julia's linear algebra code has no relative tolerance when checking for symmetry). I inquired about adding such a tolerance to Base.LinAlg.ishermitian but was informed that the choice not to include it was deliberate and that it will not be changed. As such, I am just adding a call to Hermitian here to forcibly symmetrize inv(Lam) ./ nw.kappa (since it should be symmetric anyway) to kill off these discrepancies and prevent numerical errors.
EDIT: Also added the fix to make the NormalWishart type a child of ContinuousMultivarateDistribution rather than ContinuousUnivariateDistribution.