### PR TITLE
Fixed posterior for NormalWishart.

### DIFF
--- a/src/mvnormal.jl
+++ b/src/mvnormal.jl
@@ -106,9 +106,8 @@ function posterior_canon(prior::NormalWishart, ss::MvNormalStats)
     nu = nu0 + ss.tw
     mu = (kappa0.*mu0 + ss.s) ./ kappa
 
-    Lam0 = TC0[:U]'*TC0[:U]
     z = prior.zeromean ? ss.m : ss.m - mu0
-    Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
+    Lam = Symmetric(inv(inv(TC0) + ss.s2 + kappa0*ss.tw/kappa*(z*z')))
 
     return NormalWishart(mu, kappa, cholfact(Lam), nu)
 end


### PR DESCRIPTION
The posterior calculations for most of this package are based on the paper Conjugate Bayesian analysis of the Gaussian distribution by Kevin Murphy. This paper has several typos related to the Normal-Wishart distribution. The ConjugatePriors package fixes the typos related to the pdf of the Normal-Wishart (though I would note that right now the pdf function will not run without errors for this distribution, as it relies on a function called IsApproxSymmetric that does not appear to exist - but that is a separate issue), but it does not fix the typos in the posterior. The paper cites the posterior update for the scale matrix as being:
 T_n = T_0 + S + k_0/k_n * n * (mu_0 - xhat)(mu0-xhat)'
The correct update is 
inv(T_n) = inv(T_0) + S + k_0/k_n * n * (mu_0 - xhat)(mu0-xhat)'
See https://stats.stackexchange.com/questions/153241/derivation-of-normal-wishart-posterior/324925#324925 for details.