### PR TITLE
WIP updates for 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-
 PDMats 0.6.0
 Distributions 0.14.0
 StatsFuns 0.6.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 PDMats 0.6.0
 Distributions 0.14.0
 StatsFuns 0.6.0
+SpecialFunctions

--- a/src/ConjugatePriors.jl
+++ b/src/ConjugatePriors.jl
@@ -5,6 +5,7 @@ module ConjugatePriors
 using PDMats
 using Distributions
 using StatsFuns
+using SpecialFunctions
 
 import Base: mean
 import Base.LinAlg: Cholesky

--- a/src/ConjugatePriors.jl
+++ b/src/ConjugatePriors.jl
@@ -2,13 +2,17 @@ __precompile__()
 
 module ConjugatePriors
 
+using Statistics
+using LinearAlgebra
+
 using PDMats
 using Distributions
 using StatsFuns
 using SpecialFunctions
 
-import Base: mean
-import Base.LinAlg: Cholesky
+
+import Statistics: mean
+import LinearAlgebra: Cholesky
 
 import PDMats: PDMat
 

--- a/src/dirichlet_multi.jl
+++ b/src/dirichlet_multi.jl
@@ -26,7 +26,7 @@ posterior_canon(pri::Dirichlet, ss::MultinomialStats) = DirichletCanon(pri.alpha
 function posterior_canon(pri::Dirichlet, G::Type{Multinomial}, x::Matrix{T}) where T<:Real
 	d = length(pri)
 	size(x,1) == d || throw(ArgumentError("Inconsistent argument dimensions."))
-	a = add!(sum(x, 2), pri.alpha)
+	a = add!(sum(x, dims=2), pri.alpha)
 	DirichletCanon(vec(a))
 end
 
@@ -34,7 +34,7 @@ function posterior_canon(pri::Dirichlet, G::Type{Multinomial}, x::Matrix{T}, w::
 	d = length(pri)
 	size(x) == (d, length(w)) || throw(ArgumentError("Inconsistent argument dimensions."))
 	a = copy(pri.alpha)
-	Base.LinAlg.BLAS.gemv!('N', 1.0, map(Float64, x), vec(w), 1.0, a)
+	BLAS.gemv!('N', 1.0, map(Float64, x), vec(w), 1.0, a)
 	DirichletCanon(a)
 end
 

--- a/src/dirichlet_multi.jl
+++ b/src/dirichlet_multi.jl
@@ -11,11 +11,11 @@ complete(G::Type{Categorical}, pri::Dirichlet, p::Vector{Float64}) = Categorical
 
 posterior_canon(pri::Dirichlet, ss::CategoricalStats) = DirichletCanon(pri.alpha + ss.h)
 
-function posterior_canon{T<:Integer}(pri::Dirichlet, G::Type{Categorical}, x::Array{T})
+function posterior_canon(pri::Dirichlet, G::Type{Categorical}, x::Array{T}) where T<:Integer
 	DirichletCanon(add_categorical_counts!(copy(pri.alpha), x))
 end
 
-function posterior_canon{T<:Integer}(pri::Dirichlet, G::Type{Categorical}, x::Array{T}, w::Array{Float64})
+function posterior_canon(pri::Dirichlet, G::Type{Categorical}, x::Array{T}, w::Array{Float64}) where T<:Integer
 	DirichletCanon(add_categorical_counts!(copy(pri.alpha), x, w))
 end
 
@@ -23,14 +23,14 @@ end
 
 posterior_canon(pri::Dirichlet, ss::MultinomialStats) = DirichletCanon(pri.alpha + ss.scnts)
 
-function posterior_canon{T<:Real}(pri::Dirichlet, G::Type{Multinomial}, x::Matrix{T})
+function posterior_canon(pri::Dirichlet, G::Type{Multinomial}, x::Matrix{T}) where T<:Real
 	d = length(pri)
 	size(x,1) == d || throw(ArgumentError("Inconsistent argument dimensions."))
 	a = add!(sum(x, 2), pri.alpha)
 	DirichletCanon(vec(a))
 end
 
-function posterior_canon{T<:Real}(pri::Dirichlet, G::Type{Multinomial}, x::Matrix{T}, w::Array{Float64})
+function posterior_canon(pri::Dirichlet, G::Type{Multinomial}, x::Matrix{T}, w::Array{Float64}) where T<:Real
 	d = length(pri)
 	size(x) == (d, length(w)) || throw(ArgumentError("Inconsistent argument dimensions."))
 	a = copy(pri.alpha)

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -3,9 +3,9 @@
 posterior_canon(pri, G::IncompleteFormulation, x) = posterior_canon(pri, suffstats(G, x))
 posterior_canon(pri, G::IncompleteFormulation, x, w) = posterior_canon(pri, suffstats(G, x, w))
 
-posterior{P<:Distribution}(pri::P, ss::SufficientStats) = Base.convert(P, posterior_canon(pri, ss))
-posterior{P<:Distribution}(pri::P, G::IncompleteFormulation, x) = Base.convert(P, posterior_canon(pri, G, x))
-posterior{P<:Distribution}(pri::P, G::IncompleteFormulation, x, w) = Base.convert(P, posterior_canon(pri, G, x, w))
+posterior(pri::P, ss::SufficientStats) where {P<:Distribution} = Base.convert(P, posterior_canon(pri, ss))
+posterior(pri::P, G::IncompleteFormulation, x) where {P<:Distribution} = Base.convert(P, posterior_canon(pri, G, x))
+posterior(pri::P, G::IncompleteFormulation, x, w) where {P<:Distribution} = Base.convert(P, posterior_canon(pri, G, x, w))
 
 posterior_rand(pri, ss::SufficientStats) = Base.rand(posterior_canon(pri, ss))
 posterior_rand(pri, G::IncompleteFormulation, x) = Base.rand(posterior_canon(pri, G, x))

--- a/src/mvnormal.jl
+++ b/src/mvnormal.jl
@@ -83,11 +83,11 @@ function posterior_canon(prior::NormalInverseWishart, ss::MvNormalStats)
     mu = (kappa0.*mu0 + ss.s) ./ kappa
     nu = nu0 + ss.tw
 
-    Lam0 = LamC0[:U]'*LamC0[:U]
+    Lam0 = Matrix(LamC0)
     z = prior.zeromean ? ss.m : ss.m - mu0
     Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
 
-    return NormalInverseWishart(mu, kappa, cholfact(Lam), nu)
+    return NormalInverseWishart(mu, kappa, cholesky(Lam), nu)
 end
 
 const MeanAndCovMat = Tuple{Vector{Float64}, Matrix{Float64}}
@@ -106,11 +106,11 @@ function posterior_canon(prior::NormalWishart, ss::MvNormalStats)
     nu = nu0 + ss.tw
     mu = (kappa0.*mu0 + ss.s) ./ kappa
 
-    Lam0 = TC0[:U]'*TC0[:U]
+    Lam0 = Matrix(TC0)
     z = prior.zeromean ? ss.m : ss.m - mu0
     Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
 
-    return NormalWishart(mu, kappa, cholfact(Lam), nu)
+    return NormalWishart(mu, kappa, cholesky(Lam), nu)
 end
 
 complete(G::Type{MvNormal}, pri::NormalWishart, s::MeanAndCovMat) = MvNormal(s[1], inv(PDMat(s[2])))

--- a/src/normal.jl
+++ b/src/normal.jl
@@ -101,12 +101,12 @@ function posterior_canon(prior::NormalInverseGamma, ss::NormalStats)
     # ss.tw contains the number of observations if weight wasn't used to
     # compute the sufficient statistics.
 
-    vn_inv = 1./v0 + ss.tw
+    vn_inv = 1.0/v0 + ss.tw
     mu = (mu0/v0 + ss.s) / vn_inv  # ss.s = ss.tw*ss.m = n*xbar
     shape = shape0 + 0.5*ss.tw
     scale = scale0 + 0.5*ss.s2 + 0.5/(vn_inv*v0)*ss.tw*(ss.m-mu0).^2
 
-    return NormalInverseGamma(mu, 1./vn_inv, shape, scale)
+    return NormalInverseGamma(mu, 1.0/vn_inv, shape, scale)
 end
 
 complete(G::Type{Normal}, pri::NormalInverseGamma, t::NTuple{2,Float64}) = Normal(t[1], sqrt(t[2]))

--- a/src/normalgamma.jl
+++ b/src/normalgamma.jl
@@ -31,11 +31,11 @@ insupport(::Type{NormalGamma}, x::T, tau2::T) where T<:Real =
 
 # Probably should guard agains dividing by and taking the log of 0.
 function pdf(d::NormalGamma, x::T, tau2::T) where T<:Real
-    Zinv = d.rate.^d.shape / gamma(d.shape) * sqrt(d.nu / (2.*pi))
-    return Zinv * tau2.^(d.shape-0.5) * exp(-0.5*tau2*(d.nu*(x-d.mu).^2 + 2.*d.rate))
+    Zinv = d.rate.^d.shape / gamma(d.shape) * sqrt(d.nu / (2.0*pi))
+    return Zinv * tau2.^(d.shape-0.5) * exp(-0.5*tau2*(d.nu*(x-d.mu).^2 + 2.0*d.rate))
 end
 function logpdf(d::NormalGamma, x::T, tau2::T) where T<:Real
-    lZinv = d.shape*log(d.rate) - lgamma(d.shape) + 0.5*(log(d.nu) - log(2.*pi))
+    lZinv = d.shape*log(d.rate) - lgamma(d.shape) + 0.5*(log(d.nu) - log(2.0*pi))
     return lZinv + (d.shape-0.5)*log(tau2) - 0.5*tau2*(d.nu*(x-d.mu).^2 + 2*d.rate)
 end
 
@@ -45,6 +45,6 @@ function rand(d::NormalGamma)
     if tau2 <= zero(Float64)
         tau2 = eps(Float64)
     end
-    mu = rand(Normal(d.mu, sqrt(1./(tau2*d.nu))))
+    mu = rand(Normal(d.mu, sqrt(1.0/(tau2*d.nu))))
     return mu, tau2
 end

--- a/src/normalinversechisq.jl
+++ b/src/normalinversechisq.jl
@@ -78,4 +78,4 @@ function mode(d::NormalInverseChisq)
     return μ, σ2
 end
 
-rand(d::NormalInverseChisq) = rand(NormalInverseGamma(d))
+rand(d::NormalInverseChisq) = rand(convert(NormalInverseGamma, d))

--- a/src/normalinversegamma.jl
+++ b/src/normalinversegamma.jl
@@ -32,8 +32,8 @@ insupport(::Type{NormalInverseGamma}, x::T, sig2::T) where T<:Real =
 # Probably should guard agains dividing by and taking the log of 0.
 
 function pdf(d::NormalInverseGamma, x::T, sig2::T) where T<:Real
-    Zinv = d.scale.^d.shape / gamma(d.shape) / sqrt(d.v0 * 2.*pi)
-    return Zinv * 1./(sqrt(sig2)*sig2.^(d.shape+1.)) * exp(-d.scale/sig2 - 0.5/(sig2*d.v0)*(x-d.mu).^2)
+    Zinv = d.scale.^d.shape / gamma(d.shape) / sqrt(d.v0 * 2.0*pi)
+    return Zinv * 1.0/(sqrt(sig2)*sig2.^(d.shape+1.0)) * exp(-d.scale/sig2 - 0.5/(sig2*d.v0)*(x-d.mu).^2)
 end
 
 function logpdf(d::NormalInverseGamma, x::T, sig2::T) where T<:Real

--- a/src/normalinversewishart.jl
+++ b/src/normalinversewishart.jl
@@ -39,7 +39,7 @@ function NormalInverseWishart(mu::Vector{U}, kappa::Real,
 end
 
 function insupport(::Type{NormalInverseWishart}, x::Vector{T}, Sig::Matrix{T}) where T<:Real
-    return (all(isfinite(x)) &&
+    return (all(isfinite, x) &&
            size(Sig, 1) == size(Sig, 2) &&
            isApproxSymmmetric(Sig) &&
            size(Sig, 1) == length(x) &&

--- a/src/normalinversewishart.jl
+++ b/src/normalinversewishart.jl
@@ -35,7 +35,7 @@ end
 function NormalInverseWishart(mu::Vector{U}, kappa::Real,
                               Lambda::Matrix{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(eltype(mu), typeof(kappa), typeof(nu), S)
-    return NormalInverseWishart{T}(Vector{T}(mu), T(kappa), Cholesky{T}(cholfact(Lambda)), T(nu))
+    return NormalInverseWishart{T}(Vector{T}(mu), T(kappa), Cholesky{T}(cholesky(Lambda)), T(nu))
 end
 
 function insupport(::Type{NormalInverseWishart}, x::Vector{T}, Sig::Matrix{T}) where T<:Real
@@ -77,11 +77,11 @@ function logpdf(niw::NormalInverseWishart, x::Vector{T}, Sig::Matrix{T}) where T
         logp::T = hnu * logdet(Lamchol)
         logp -= hnu * p * log(2.)
         logp -= logmvgamma(p, hnu)
-        logp -= hp * (log(2.*pi) - log(kappa))
+        logp -= hp * (log(2.0*pi) - log(kappa))
         
         # Inverse-Wishart
         logp -= (hnu + hp + 1.) * logdet(Sig)
-        logp -= 0.5 * trace(Sig \ (Lamchol[:U]' * Lamchol[:U]))
+        logp -= 0.5 * tr(Sig \ Matrix(Lamchol))
         
         # Normal
         z = niw.zeromean ? x : x - mu

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -38,7 +38,7 @@ function NormalWishart(mu::Vector{T}, kappa::T,
 end
 
 function insupport(::Type{NormalWishart}, x::Vector{T}, Lam::Matrix{T}) where T<:Real
-    return (all(isfinite(x)) &&
+    return (all(isfinite, x) &&
            size(Lam, 1) == size(Lam, 2) &&
            isApproxSymmmetric(Lam) &&
            size(Lam, 1) == length(x) &&

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -34,7 +34,7 @@ end
 
 function NormalWishart(mu::Vector{T}, kappa::T,
                        Tmat::Matrix{T}, nu::T) where T<:Real
-    NormalWishart{T}(mu, kappa, cholfact(Tmat), nu)
+    NormalWishart{T}(mu, kappa, cholesky(Tmat), nu)
 end
 
 function insupport(::Type{NormalWishart}, x::Vector{T}, Lam::Matrix{T}) where T<:Real
@@ -69,7 +69,7 @@ function logpdf(nw::NormalWishart, x::Vector{T}, Lam::Matrix{T}) where T<:Real
 
         # Wishart (MvNormal contributes 0.5 as well)
         logp += (hnu - hp) * logdet(Lam)
-        logp -= 0.5 * trace(Tchol \ Lam)
+        logp -= 0.5 * tr(Tchol \ Lam)
 
         # Normal
         z = nw.zeromean ? x : x - mu

--- a/test/conjugates.jl
+++ b/test/conjugates.jl
@@ -139,7 +139,7 @@ end
     x = rand(Multinomial(10, [0.2, 0.3, 0.5]), n)
     p = posterior(pri, Multinomial, x)
     @test isa(p, Dirichlet)
-    @test p.alpha ≈ pri.alpha + vec(sum(x, 2))
+    @test p.alpha ≈ pri.alpha + vec(sum(x, dims=2))
 
     r = posterior_mode(pri, Multinomial, x)
     @test r ≈ mode(p)

--- a/test/conjugates_normal.jl
+++ b/test/conjugates_normal.jl
@@ -1,6 +1,8 @@
 using Distributions
 using ConjugatePriors
 
+using Random: srand
+
 using ConjugatePriors: NormalGamma, NormalInverseGamma, NormalInverseChisq
 using ConjugatePriors: posterior, posterior_rand, posterior_mode, posterior_randmodel, fit_map
 
@@ -123,10 +125,10 @@ w = rand(100)
         post = posterior(pri, Normal, x)
         @test isa(post, NormalInverseGamma)
 
-        @test post.mu ≈ (mu0/v0 + n*mean(x))/(1./v0 + n)
-        @test post.v0 ≈ 1./(1./v0 + n)
+        @test post.mu ≈ (mu0/v0 + n*mean(x))/(1.0/v0 + n)
+        @test post.v0 ≈ 1.0/(1.0/v0 + n)
         @test post.shape ≈ shape0 + 0.5*n
-        @test post.scale ≈ scale0 + 0.5*(n-1)*var(x) + n./v0./(n + 1./v0)*0.5*(mean(x)-mu0).^2
+        @test post.scale ≈ scale0 + 0.5*(n-1)*var(x) + n./v0./(n + 1.0/v0)*0.5*(mean(x)-mu0).^2
 
         ps = posterior_randmodel(pri, Normal, x)
 
@@ -154,9 +156,9 @@ w = rand(100)
         ν0 = 10.0
 
         pri = NormalInverseChisq(μ0, σ20, κ0, ν0)
-        pri2 = NormalInverseGamma(pri)
+        pri2 = convert(NormalInverseGamma, pri)
 
-        @test NormalInverseChisq(pri2) == pri
+        @test convert(NormalInverseChisq, pri2) == pri
 
         @test mode(pri2) == mode(pri)
         @test mean(pri2) == mean(pri)
@@ -168,7 +170,7 @@ w = rand(100)
         post = posterior(pri, Normal, x)
         post2 = posterior(pri2, Normal, x)
         @test isa(post, NormalInverseChisq)
-        @test NormalInverseChisq(post2) == post
+        @test convert(NormalInverseChisq, post2) == post
 
         for _ in 1:10
             x = rand(post)
@@ -189,7 +191,7 @@ w = rand(100)
 
         mu_true = 2.
         tau2_true = 3.
-        x = rand(Normal(mu_true, 1./tau2_true), n)
+        x = rand(Normal(mu_true, 1.0/tau2_true), n)
 
         mu0 = 2.
         nu0 = 3.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Compat
 using Compat.Test
 
+using LinearAlgebra
+
 @testset "Conjugate priors" begin
     tests = ["conjugates",
              "conjugates_normal",


### PR DESCRIPTION
So far to get tests to pass:

* replace `all(isfinite(x))` with `all(isfinite, x)`
* `using SpecialFunctions`

Still need to take care of deprecation warnings:

* [x] LinearAlgebra stdlib
* [x] an `I` for an `eye`
* [x] `.U` instead of `[:U]` for cholesky
* [x] removed `full`
* [x] `dims` kwarg for mean etc.

And probably many more.  I've lost track of what's still backwards compatible with 0.6, so we should decide whether it makes sense to drop 0.6 altogether and let femtocleaner go to town...