### PR TITLE
export interface functions and distribution types

### DIFF
--- a/src/ConjugatePriors.jl
+++ b/src/ConjugatePriors.jl
@@ -51,6 +51,22 @@ import Distributions:
     isApproxSymmmetric,
     hasCholesky
 
+export
+    # conjugate prior distributions defined here
+    NormalInverseChisq,
+    NormalGamma,
+    NormalInverseGamma,
+    NormalWishart,
+    NormalInverseWishart,
+
+    # inteface
+    posterior,
+    posterior_canon,
+    posterior_rand,
+    posterior_rand!,
+    posterior_randmodel,
+    posterior_mode,
+    fit_map
 
 include("fallbacks.jl")
 include("beta_binom.jl")


### PR DESCRIPTION
I finally got fed up with having to manually `using` the normal priors defined here.  I don't think there's any good reason to not export them but I could be wrong.