### PR TITLE
use abstract array where possible

### DIFF
--- a/src/mvnormal.jl
+++ b/src/mvnormal.jl
@@ -83,7 +83,7 @@ function posterior_canon(prior::NormalInverseWishart, ss::MvNormalStats)
     mu = (kappa0.*mu0 + ss.s) ./ kappa
     nu = nu0 + ss.tw
 
-    Lam0 = Matrix(LamC0)
+    Lam0 = AbstractMatrix(LamC0)
     z = prior.zeromean ? ss.m : ss.m - mu0
     Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
 
@@ -106,7 +106,7 @@ function posterior_canon(prior::NormalWishart, ss::MvNormalStats)
     nu = nu0 + ss.tw
     mu = (kappa0.*mu0 + ss.s) ./ kappa
 
-    Lam0 = Matrix(TC0)
+    Lam0 = AbstractMatrix(TC0)
     z = prior.zeromean ? ss.m : ss.m - mu0
     Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
 

--- a/src/mvnormal.jl
+++ b/src/mvnormal.jl
@@ -83,7 +83,7 @@ function posterior_canon(prior::NormalInverseWishart, ss::MvNormalStats)
     mu = (kappa0.*mu0 + ss.s) ./ kappa
     nu = nu0 + ss.tw
 
-    Lam0 = AbstractMatrix(LamC0)
+    Lam0 = convert(AbstractMatrix, LamC0)
     z = prior.zeromean ? ss.m : ss.m - mu0
     Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
 
@@ -106,7 +106,7 @@ function posterior_canon(prior::NormalWishart, ss::MvNormalStats)
     nu = nu0 + ss.tw
     mu = (kappa0.*mu0 + ss.s) ./ kappa
 
-    Lam0 = AbstractMatrix(TC0)
+    Lam0 = convert(AbstractMatrix, TC0)
     z = prior.zeromean ? ss.m : ss.m - mu0
     Lam = Lam0 + ss.s2 + kappa0*ss.tw/kappa*(z*z')
 

--- a/src/normalinversewishart.jl
+++ b/src/normalinversewishart.jl
@@ -29,13 +29,19 @@ end
 function NormalInverseWishart(mu::AbstractVector{U}, kappa::Real,
                                 Lamchol::Cholesky{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(eltype(mu), typeof(kappa), typeof(nu), S)
-    return NormalInverseWishart{T}(AbstractVector{T}(mu), T(kappa), Cholesky{T}(Lamchol), T(nu))
+    return NormalInverseWishart{T}(convert(AbstractVector{T}, mu),
+                                   T(kappa),
+                                   Cholesky{T}(Lamchol),
+                                   T(nu))
 end
 
 function NormalInverseWishart(mu::AbstractVector{U}, kappa::Real,
                               Lambda::AbstractMatrix{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(eltype(mu), typeof(kappa), typeof(nu), S)
-    return NormalInverseWishart{T}(AbstractVector{T}(mu), T(kappa), Cholesky{T}(cholesky(Lambda)), T(nu))
+    return NormalInverseWishart{T}(convert(AbstractVector{T}, mu),
+                                   T(kappa),
+                                   Cholesky{T}(cholesky(Lambda)),
+                                   T(nu))
 end
 
 function insupport(::Type{NormalInverseWishart}, x::AbstractVector{T}, Sig::AbstractMatrix{T}) where T<:Real
@@ -81,7 +87,7 @@ function logpdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::AbstractMa
 
         # Inverse-Wishart
         logp -= (hnu + hp + 1.) * logdet(Sig)
-        logp -= 0.5 * tr(Sig \ AbstractMatrix(Lamchol))
+        logp -= 0.5 * tr(Sig \ convert(AbstractMatrix, Lamchol))
 
         # Normal
         z = niw.zeromean ? x : x - mu

--- a/src/normalinversewishart.jl
+++ b/src/normalinversewishart.jl
@@ -6,12 +6,12 @@
 struct NormalInverseWishart{T<:Real} <: ContinuousUnivariateDistribution
     dim::Int
     zeromean::Bool
-    mu::Vector{T}
+    mu::AbstractVector{T}
     kappa::T              # This scales precision (inverse covariance)
     Lamchol::Cholesky{T}  # Covariance matrix (well, sqrt of one)
     nu::T
 
-    function NormalInverseWishart{T}(mu::Vector{T}, kappa::T,
+    function NormalInverseWishart{T}(mu::AbstractVector{T}, kappa::T,
                                   Lamchol::Cholesky{T}, nu::T) where T<:Real
         # Probably should put some error checking in here
         d = length(mu)
@@ -26,19 +26,19 @@ struct NormalInverseWishart{T<:Real} <: ContinuousUnivariateDistribution
     end
 end
 
-function NormalInverseWishart(mu::Vector{U}, kappa::Real,
+function NormalInverseWishart(mu::AbstractVector{U}, kappa::Real,
                                 Lamchol::Cholesky{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(eltype(mu), typeof(kappa), typeof(nu), S)
-    return NormalInverseWishart{T}(Vector{T}(mu), T(kappa), Cholesky{T}(Lamchol), T(nu))
+    return NormalInverseWishart{T}(AbstractVector{T}(mu), T(kappa), Cholesky{T}(Lamchol), T(nu))
 end
 
-function NormalInverseWishart(mu::Vector{U}, kappa::Real,
+function NormalInverseWishart(mu::AbstractVector{U}, kappa::Real,
                               Lambda::Matrix{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(eltype(mu), typeof(kappa), typeof(nu), S)
-    return NormalInverseWishart{T}(Vector{T}(mu), T(kappa), Cholesky{T}(cholesky(Lambda)), T(nu))
+    return NormalInverseWishart{T}(AbstractVector{T}(mu), T(kappa), Cholesky{T}(cholesky(Lambda)), T(nu))
 end
 
-function insupport(::Type{NormalInverseWishart}, x::Vector{T}, Sig::Matrix{T}) where T<:Real
+function insupport(::Type{NormalInverseWishart}, x::AbstractVector{T}, Sig::Matrix{T}) where T<:Real
     return (all(isfinite, x) &&
            size(Sig, 1) == size(Sig, 2) &&
            isApproxSymmmetric(Sig) &&
@@ -50,17 +50,17 @@ end
     params(niw::NormalInverseWishart)
 
 The parameters are
-* μ::Vector{T<:Real} the expected mean vector
+* μ::AbstractVector{T<:Real} the expected mean vector
 * Λchol::Cholesky{T<:Real} the Cholesky decomposition of the scale matrix
 * κ::T<:Real prior pseudocount for the mean
 * ν::T<:Real prior pseudocount for the covariance
 """
 params(niw::NormalInverseWishart) = (niw.mu, niw.Lamchol, niw.kappa, niw.nu)
 
-pdf(niw::NormalInverseWishart, x::Vector{T}, Sig::Matrix{T}) where T<:Real =
+pdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::Matrix{T}) where T<:Real =
         exp(logpdf(niw, x, Sig))
 
-function logpdf(niw::NormalInverseWishart, x::Vector{T}, Sig::Matrix{T}) where T<:Real
+function logpdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::Matrix{T}) where T<:Real
     if !insupport(NormalInverseWishart, x, Sig)
         return -Inf
     else

--- a/src/normalinversewishart.jl
+++ b/src/normalinversewishart.jl
@@ -38,7 +38,7 @@ function NormalInverseWishart(mu::AbstractVector{U}, kappa::Real,
     return NormalInverseWishart{T}(AbstractVector{T}(mu), T(kappa), Cholesky{T}(cholesky(Lambda)), T(nu))
 end
 
-function insupport(::Type{NormalInverseWishart}, x::AbstractVector{T}, Sig::Matrix{T}) where T<:Real
+function insupport(::Type{NormalInverseWishart}, x::AbstractVector{T}, Sig::AbstractMatrix{T}) where T<:Real
     return (all(isfinite, x) &&
            size(Sig, 1) == size(Sig, 2) &&
            isApproxSymmmetric(Sig) &&
@@ -57,10 +57,10 @@ The parameters are
 """
 params(niw::NormalInverseWishart) = (niw.mu, niw.Lamchol, niw.kappa, niw.nu)
 
-pdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::Matrix{T}) where T<:Real =
+pdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::AbstractMatrix{T}) where T<:Real =
         exp(logpdf(niw, x, Sig))
 
-function logpdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::Matrix{T}) where T<:Real
+function logpdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::AbstractMatrix{T}) where T<:Real
     if !insupport(NormalInverseWishart, x, Sig)
         return -Inf
     else
@@ -81,7 +81,7 @@ function logpdf(niw::NormalInverseWishart, x::AbstractVector{T}, Sig::Matrix{T})
 
         # Inverse-Wishart
         logp -= (hnu + hp + 1.) * logdet(Sig)
-        logp -= 0.5 * tr(Sig \ Matrix(Lamchol))
+        logp -= 0.5 * tr(Sig \ AbstractMatrix(Lamchol))
 
         # Normal
         z = niw.zeromean ? x : x - mu

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -26,14 +26,14 @@ struct NormalWishart{T<:Real,V<:AbstractVector{T},M<:AbstractMatrix{T}} <: Conti
     end
 end
 
-function NormalWishart(mu::Vector{U}, kappa::Real,
+function NormalWishart(mu::AbstractVector{U}, kappa::Real,
                        Tchol::Cholesky{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(U,S,typeof(kappa), typeof(nu))
-    return NormalWishart{T}(Vector{T}(mu),T(kappa),Cholesky{T}(Tchol), T(nu))
+    return NormalWishart{T}(convert(AbstractVector{T}, mu),T(kappa),Cholesky{T}(Tchol), T(nu))
 end
 
-function NormalWishart(mu::Vector{T}, kappa::T,
-                       Tmat::Matrix{T}, nu::T) where T<:Real
+function NormalWishart(mu::AbstractVector{T}, kappa::T,
+                       Tmat::AbstractMatrix{T}, nu::T) where T<:Real
     NormalWishart{T}(mu, kappa, cholesky(Tmat), nu)
 end
 

--- a/src/normalwishart.jl
+++ b/src/normalwishart.jl
@@ -3,16 +3,16 @@
 # a reference.  Note that there were some typos in that document so the code
 # here may not correspond exactly.
 
-struct NormalWishart{T<:Real} <: ContinuousMultivariateDistribution
+struct NormalWishart{T<:Real,V<:AbstractVector{T},M<:AbstractMatrix{T}} <: ContinuousMultivariateDistribution
     dim::Int
     zeromean::Bool
-    mu::Vector{T}
+    mu::V
     kappa::T
-    Tchol::Cholesky{T}  # Precision matrix (well, sqrt of one)
+    Tchol::Cholesky{T,M}  # Precision matrix (well, sqrt of one)
     nu::T
 
-    function NormalWishart{T}(mu::Vector{T}, kappa::T,
-                                  Tchol::Cholesky{T}, nu::T) where T<:Real
+    function NormalWishart{T}(mu::AbstractVector{T}, kappa::T,
+                              Tchol::Cholesky{T,M}, nu::T) where {T<:Real, M<:AbstractMatrix{T}}
         # Probably should put some error checking in here
         d = length(mu)
         zmean::Bool = true
@@ -22,12 +22,12 @@ struct NormalWishart{T<:Real} <: ContinuousMultivariateDistribution
                 break
             end
         end
-        new(d, zmean, mu, T(kappa), Tchol, T(nu))
+        new{T,typeof(mu),M}(d, zmean, mu, T(kappa), Tchol, T(nu))
     end
 end
 
 function NormalWishart(mu::Vector{U}, kappa::Real,
-                                Tchol::Cholesky{S}, nu::Real) where {S<:Real, U<:Real}
+                       Tchol::Cholesky{S}, nu::Real) where {S<:Real, U<:Real}
     T = promote_type(U,S,typeof(kappa), typeof(nu))
     return NormalWishart{T}(Vector{T}(mu),T(kappa),Cholesky{T}(Tchol), T(nu))
 end


### PR DESCRIPTION
This widens type signatures in a bunch of places where `Matrix` is hardcoded to be `AbstractMatrix`, and adds type parameters to the `Normal[Inverse]Wishart` structs that record the types of the mean and covariance matrix fields.

I did this primarily to support StaticArrays, which gives me large speed ups when doing lots of posterior calculations (as in my [particle filter code](https://github.com/kleinschmidt/Particles.jl)).  The support isn't perfect, because in a number of places we fall back to Distributions.jl PDMats.jl, both of which hard-code something more specific than AbstractMatrix in a number of places.  But it does get the posterior updates correct.