### PR TITLE
Remove `__precompile__()`, because it is the default for >= v0.7.0.

### DIFF
--- a/src/ConjugatePriors.jl
+++ b/src/ConjugatePriors.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module ConjugatePriors
 
 using Statistics


### PR DESCRIPTION
Remove `__precompile__()`, because it is the default for >= v0.7.0.
See https://github.com/JuliaLang/julia/pull/26991.